### PR TITLE
fixing duplicate include bug when field tag is inside another plugin tag pair

### DIFF
--- a/system/expressionengine/third_party/markdown/ft.markdown.php
+++ b/system/expressionengine/third_party/markdown/ft.markdown.php
@@ -98,7 +98,7 @@ class Markdown_ft extends EE_Fieldtype {
 		// 	)
 		// );
 		//Markdown here
-		require(PATH_THIRD . '/markdown/library/markdown.php');
+		require_once(PATH_THIRD . '/markdown/library/markdown.php');
 		return Markdown($data);
 	}
 	


### PR DESCRIPTION
fixes PHP error that occurs when Surgedown field content is displayed inside another plugin tag pair
